### PR TITLE
Fix for testing failures

### DIFF
--- a/R/safedata_network.R
+++ b/R/safedata_network.R
@@ -71,9 +71,9 @@ NULL
 
 #' Attempt to download a URL resource, failing gracefully.
 #'
-#' This function tries to fetch the HEAD for the resource and handles failure to
-#' resolve (such as a bad safedata API url), timeouts and then actual HTTP error
-#' codes. If none of those occur, the resource is downloaded.
+#' This function tries to fetch a resource from a URL and handles failure to
+#' resolve the resource (bad URLs), timeouts and then actual HTTP error
+#' codes.
 #'
 #' If the download fails, the function returns FALSE and the return value
 #' attribute 'fail_msg' is used to provide details. Otherwise, an
@@ -84,8 +84,7 @@ NULL
 #' @section Note:
 #'
 #' This function contains code to simulate network failures of varying kinds (no
-#' network, no API, specific resource unavailable) for use in unit testing that
-#' the safedata package handles theses errors gracefully.
+#' network, no API, specific resource unavailable) for use in unit testing.
 #'
 #' @param url The URL to download.
 #' @param local_path A path to a file in which to save the URL content.
@@ -142,7 +141,9 @@ try_to_download <- function(url, local_path = NULL, timeout = 10) {
             attr(fail, "fail_msg") <- response
             return(fail)
         } else {
-            attr(fail, "fail_msg") <- paste0("Unknown curl response: ", response)
+            attr(fail, "fail_msg") <- paste0(
+                "Unknown curl response: ", response
+            )
             return(fail)
         }
     }

--- a/build_notes.md
+++ b/build_notes.md
@@ -26,7 +26,7 @@ of three places:
 
 1. Markup inside the `R` source files - there are blocks of comments starting
    with `#'` that contain all of the documentation that goes into the normal R
-   documentaion (`.Rd`) files.
+   documentation (`.Rd`) files.
 2. Vignettes, formatted as `Rmarkdown` files in the `vignettes` directory.
 
 When the documentation has been changed then the `.Rd` files in `man` and any
@@ -185,7 +185,7 @@ only checks that network failures are handled gracefully. Those have to be passi
 before the package can be built so:
 
 ```sh
-Rscript -e "devtools::test()
+Rscript -e "devtools::test()"
 ```
 
 If the tests pass, then the second step is to build and install the package with
@@ -286,7 +286,7 @@ version number (`-9000` is used to indicate code in development between versions
 Version: 1.0.5-9000
 ```
 
-to 
+to
 
 ```txt
 Version: 1.0.6

--- a/tests/testthat/test-safedata_network.R
+++ b/tests/testthat/test-safedata_network.R
@@ -69,7 +69,7 @@ test_that("Good URL works and returns object to memory", {
 
     success <- safedata:::try_to_download("https://httpbin.org/base64/c2FmZWRhdGE=")
 
-    # Screen for failure of the download
+    # Screen for failure of the download due to timeout
     if (is.logical(success) && isFALSE(success)) {
         skip("Download failed")
     }

--- a/tests/testthat/test-safedata_network.R
+++ b/tests/testthat/test-safedata_network.R
@@ -17,11 +17,10 @@ test_that("no internet fails gracefully", {
 # check function to skip if there is a network outage.
 
 internet_unavailable <- function() {
-    return(! curl::has_internet())
+    return(!curl::has_internet())
 }
 
 test_that("bad host fails gracefully", {
-
     if (internet_unavailable()) {
         skip("No internet - skipping test")
     }
@@ -30,24 +29,21 @@ test_that("bad host fails gracefully", {
 
     expect_false(success)
     expect_match(attr(success, "fail_msg"), regexp = "URL not found")
-
 })
 
 test_that("timeout fails gracefully", {
-
     if (internet_unavailable()) {
         skip("No internet - skipping test")
     }
 
-     success <- safedata:::try_to_download("https://httpbin.org/delay/2",
-                                          timeout = 1)
+    success <- safedata:::try_to_download("https://httpbin.org/delay/2",
+        timeout = 1
+    )
     expect_false(success)
     expect_match(attr(success, "fail_msg"), regexp = "URL timed out")
-
 })
 
 test_that("URL errors fails gracefully", {
-
     if (internet_unavailable()) {
         skip("No internet - skipping test")
     }
@@ -55,16 +51,14 @@ test_that("URL errors fails gracefully", {
     success <- safedata:::try_to_download("https://httpbin.org/status/404")
     expect_false(success)
     expect_match(attr(success, "fail_msg"), regexp = "URL error")
-
 })
 
 test_that("Good URL works and returns object to memory", {
-
     if (internet_unavailable()) {
         skip("No internet - skipping test")
     }
 
-    success <-  safedata:::try_to_download("https://httpbin.org/base64/c2FmZWRhdGE=")
+    success <- safedata:::try_to_download("https://httpbin.org/base64/c2FmZWRhdGE=")
 
     # Screen for failure of the download (get FALSE, not a response object)
     expect_false(is.logical(success) && success == TRUE)
@@ -72,10 +66,23 @@ test_that("Good URL works and returns object to memory", {
     expect_equal(rawToChar(success$content), "safedata")
 })
 
-test_that("no internet and safedata dir creation fails gracefully", {
+test_that("Bad path fails gracefully", {
+    if (internet_unavailable()) {
+        skip("No internet - skipping test")
+    }
 
+    success <- safedata:::try_to_download(
+        "https://httpbin.org/base64/c2FmZWRhdGE=",
+        local_path = "/does/not/exist"
+    )
+
+    expect_false(success)
+    expect_match(attr(success, "fail_msg"), regexp = "Failed to open file")
+})
+
+test_that("no internet and safedata dir creation fails gracefully", {
     Sys.setenv(NETWORK_DOWN = TRUE)
-    temp_safe_dir <- file.path(tempdir(), 'test_safe_data')
+    temp_safe_dir <- file.path(tempdir(), "test_safe_data")
 
     success <- expect_message(
         safedata::set_safe_dir(temp_safe_dir, create = TRUE),
@@ -89,9 +96,8 @@ test_that("no internet and safedata dir creation fails gracefully", {
 })
 
 test_that("API down and safedata dir creation fails gracefully", {
-
     Sys.setenv(URL_DOWN = TRUE)
-    temp_safe_dir <- file.path(tempdir(), 'test_safe_data')
+    temp_safe_dir <- file.path(tempdir(), "test_safe_data")
 
     success <- expect_message(
         safedata::set_safe_dir(temp_safe_dir, create = TRUE),


### PR DESCRIPTION
This PR:

* Updates `try_to_download` to remove the HEAD test and just try and GET the resource right away. The old implementation carefully checked we could get the HEAD for the resource but then assumed GET would succeed. This now just puts the GET directly in the checking.
* Updates some of the `testthat` suite to screen for http://httpbin.org timeouts  in what should be successful tests.

Fixes #3.