### PR TITLE
Added taxon Auth to search_safe_taxa

### DIFF
--- a/R/api_mockr.R
+++ b/R/api_mockr.R
@@ -64,7 +64,7 @@ mock_api_urls <- list(
         content = "taxa_name_Formicidae.json",
         status_code = 200L
     ),
-    "http://example.safedata.server/api/search/taxa?gbif_id=4342" = list(
+    "http://example.safedata.server/api/search/taxa?taxon_id=4342&auth=GBIF" = list(
         content = "taxa_gbif_id_4342.json",
         status_code = 200L
     ),

--- a/R/search_safe.R
+++ b/R/search_safe.R
@@ -168,7 +168,7 @@ search_taxa <- function(taxon_name = NULL, taxon_rank = NULL,
     # check inputs
     validate_query_param("taxon_name", taxon_name)
     validate_query_param("taxon_rank", taxon_rank)
-    validate_query_param("taxon_id", gbif_id, class = "numeric")
+    validate_query_param("taxon_id", taxon_id, class = "numeric")
     validate_query_param("taxon_auth", taxon_auth)
 
     params <- c(

--- a/R/search_safe.R
+++ b/R/search_safe.R
@@ -157,17 +157,24 @@ search_authors <- function(author, ids = NULL, most_recent = FALSE) {
 }
 
 
-search_taxa <- function(taxon_name = NULL, taxon_rank = NULL, gbif_id = NULL,
+search_taxa <- function(taxon_name = NULL, taxon_rank = NULL,
+                        taxon_id = NULL, taxon_auth = c("GBIF", "NCBI"),
                         ids = NULL, most_recent = FALSE) {
-    #' @describeIn search_safe Search by taxon name, rank or GBIF ID.
+    #' @describeIn search_safe Search by taxon name, rank or taxon ID.
     #' @export
+
+    taxon_auth <- match.arg(taxon_auth)
 
     # check inputs
     validate_query_param("taxon_name", taxon_name)
     validate_query_param("taxon_rank", taxon_rank)
-    validate_query_param("gbif_id", gbif_id, class = "numeric")
+    validate_query_param("taxon_id", gbif_id, class = "numeric")
+    validate_query_param("taxon_auth", taxon_auth)
 
-    params <- c(name = taxon_name, rank = taxon_rank, gbif_id = gbif_id)
+    params <- c(
+        name = taxon_name, rank = taxon_rank,
+        taxon_id = taxon_id, auth = taxon_auth
+    )
     return(safe_api_search("taxa", params, ids, most_recent))
 }
 

--- a/R/search_safe.R
+++ b/R/search_safe.R
@@ -55,7 +55,9 @@
 #'    full (or partial) names.
 #' @param taxon_name The scientific name of a taxon to search for.
 #' @param taxon_rank A taxonomic rank to search for.
-#' @param gbif_id A GBIF taxonomic ID number.
+#' @param taxon_id A numeric taxon ID number from GBIF or NCBI.
+#' @param taxon_auth One of GBIF or NCBI. If not specified, results will match
+#'     against taxa validated against either taxonomy database.
 #' @param text Character string to look for within a SAFE dataset, worksheet,
 #'    title, field description, and dataset keywords.
 #' @param wkt A well-known text geometry string, assumed to use latitude and

--- a/R/search_safe.R
+++ b/R/search_safe.R
@@ -82,7 +82,7 @@
 #' search_fields(field_text = "temperature", field_type = "numeric")
 #' search_authors("Ewers")
 #' search_taxa(taxon_name = "Formicidae")
-#' search_taxa(gbif_id = 4342)
+#' search_taxa(taxon_id = 4342, taxon_auth = "GBIF")
 #' search_taxa(taxon_rank = "family")
 #' search_text("forest")
 #' search_text("ant")

--- a/R/search_safe.R
+++ b/R/search_safe.R
@@ -158,12 +158,15 @@ search_authors <- function(author, ids = NULL, most_recent = FALSE) {
 
 
 search_taxa <- function(taxon_name = NULL, taxon_rank = NULL,
-                        taxon_id = NULL, taxon_auth = c("GBIF", "NCBI"),
+                        taxon_id = NULL, taxon_auth = NULL,
                         ids = NULL, most_recent = FALSE) {
     #' @describeIn search_safe Search by taxon name, rank or taxon ID.
     #' @export
 
-    taxon_auth <- match.arg(taxon_auth)
+    # Validate taxon auth unless it is missing
+    if (!is.null(taxon_auth)) {
+        taxon_auth <- match.arg(taxon_auth, c("GBIF", "NCBI"))
+    }
 
     # check inputs
     validate_query_param("taxon_name", taxon_name)

--- a/man/mock_api_urls.Rd
+++ b/man/mock_api_urls.Rd
@@ -4,7 +4,9 @@
 \name{mock_api_urls}
 \alias{mock_api_urls}
 \title{URLs handled by mock_api}
-\format{An object of class \code{list} of length 26.}
+\format{
+An object of class \code{list} of length 26.
+}
 \usage{
 mock_api_urls
 }

--- a/man/safedata_env.Rd
+++ b/man/safedata_env.Rd
@@ -5,7 +5,9 @@
 \alias{safedata_env}
 \alias{index}
 \title{Index file memory cache}
-\format{An object of class \code{environment} of length 0.}
+\format{
+An object of class \code{environment} of length 0.
+}
 \usage{
 safedata_env
 }

--- a/man/search_safe.Rd
+++ b/man/search_safe.Rd
@@ -24,7 +24,8 @@ search_authors(author, ids = NULL, most_recent = FALSE)
 search_taxa(
   taxon_name = NULL,
   taxon_rank = NULL,
-  gbif_id = NULL,
+  taxon_id = NULL,
+  taxon_auth = NULL,
   ids = NULL,
   most_recent = FALSE
 )
@@ -66,8 +67,6 @@ full (or partial) names.}
 
 \item{taxon_rank}{A taxonomic rank to search for.}
 
-\item{gbif_id}{A GBIF taxonomic ID number.}
-
 \item{text}{Character string to look for within a SAFE dataset, worksheet,
 title, field description, and dataset keywords.}
 
@@ -78,6 +77,8 @@ longitude in WGS84 (EPSG:4326).}
 
 \item{distance}{A buffer distance for spatial searches, giving the distance
 in metres within which to match either location or wkt searches.}
+
+\item{gbif_id}{A GBIF taxonomic ID number.}
 }
 \value{
 An object of class \code{\link{safe_record_set}} of datasets that
@@ -113,7 +114,7 @@ date is provided.
 
 \item \code{search_authors}: Search by dataset author
 
-\item \code{search_taxa}: Search by taxon name, rank or GBIF ID.
+\item \code{search_taxa}: Search by taxon name, rank or taxon ID.
 
 \item \code{search_text}: Search dataset, worksheet and field titles
 and descriptions
@@ -152,31 +153,31 @@ coordinate information.
 }
 
 \examples{
-   \donttest{
-   search_dates("2014-06-12")
-   search_dates(as.POSIXct(c("2014-06-12", "2015-06-11")))
-   search_dates(c("2014-06-12", "2015-06-11"), match_type = "contain")
-   search_fields(field_text = "temperature")
-   search_fields(field_type = "numeric")
-   search_fields(field_text = "temperature", field_type = "numeric")
-   search_authors("Ewers")
-   search_taxa(taxon_name = "Formicidae")
-   search_taxa(gbif_id = 4342)
-   search_taxa(taxon_rank = "family")
-   search_text("forest")
-   search_text("ant")
-   search_spatial(wkt = "Point(116.5 4.75)")
-   search_spatial(wkt = "Point(116.5 4.75)", distance = 100000)
-   search_spatial(wkt = "Polygon((110 0, 110 10,120 10,120 0,110 0))")
-   search_spatial(location = "A_1")
-   search_spatial(location = "A_1", distance = 2500)
+\donttest{
+search_dates("2014-06-12")
+search_dates(as.POSIXct(c("2014-06-12", "2015-06-11")))
+search_dates(c("2014-06-12", "2015-06-11"), match_type = "contain")
+search_fields(field_text = "temperature")
+search_fields(field_type = "numeric")
+search_fields(field_text = "temperature", field_type = "numeric")
+search_authors("Ewers")
+search_taxa(taxon_name = "Formicidae")
+search_taxa(taxon_id = 4342, taxon_auth = "GBIF")
+search_taxa(taxon_rank = "family")
+search_text("forest")
+search_text("ant")
+search_spatial(wkt = "Point(116.5 4.75)")
+search_spatial(wkt = "Point(116.5 4.75)", distance = 100000)
+search_spatial(wkt = "Polygon((110 0, 110 10,120 10,120 0,110 0))")
+search_spatial(location = "A_1")
+search_spatial(location = "A_1", distance = 2500)
 
-   # combining searches using logical operators
-   fish <- search_taxa('Actinopterygii')
-   odonates <- search_taxa("Odonata")
-   ewers <- search_authors("Ewers")
-   aquatic <- fish | odonates
-   aquatic_ewers <- aquatic & ewers
-   all_in_one <- (fish | odonates) & ewers
-   }
+# combining searches using logical operators
+fish <- search_taxa("Actinopterygii")
+odonates <- search_taxa("Odonata")
+ewers <- search_authors("Ewers")
+aquatic <- fish | odonates
+aquatic_ewers <- aquatic & ewers
+all_in_one <- (fish | odonates) & ewers
+}
 }

--- a/man/search_safe.Rd
+++ b/man/search_safe.Rd
@@ -67,6 +67,11 @@ full (or partial) names.}
 
 \item{taxon_rank}{A taxonomic rank to search for.}
 
+\item{taxon_id}{A numeric taxon ID number from GBIF or NCBI.}
+
+\item{taxon_auth}{One of GBIF or NCBI. If not specified, results will match
+against taxa validated against either taxonomy database.}
+
 \item{text}{Character string to look for within a SAFE dataset, worksheet,
 title, field description, and dataset keywords.}
 
@@ -77,8 +82,6 @@ longitude in WGS84 (EPSG:4326).}
 
 \item{distance}{A buffer distance for spatial searches, giving the distance
 in metres within which to match either location or wkt searches.}
-
-\item{gbif_id}{A GBIF taxonomic ID number.}
 }
 \value{
 An object of class \code{\link{safe_record_set}} of datasets that

--- a/man/try_to_download.Rd
+++ b/man/try_to_download.Rd
@@ -33,14 +33,9 @@ and the function returns TRUE to indicate success.
 \section{Note}{
 
 
-<<<<<<< HEAD
-This function contains code to simulate network failures of varying kinds (no
-network, no API, specific resource unavailable) for use in unit testing.
-=======
 This function contains code to simulate network failures of varying
 kinds (no network, no API, specific resource unavailable) for use in
 unit testing.
->>>>>>> 6bcd6446f02adb304c2bfc28e7c40b92b139d4ad
 }
 
 \keyword{internal}

--- a/vignettes/using_safe_data.Rmd
+++ b/vignettes/using_safe_data.Rmd
@@ -195,13 +195,18 @@ ants <- search_taxa("Formicidae")
 print(ants)
 ```
 
-The taxonomic index is built around the GBIF backbone taxonomic database and
-include the following core taxonomic levels: kingdom, phylum, class, order,
-family, genus, species and subspecies. It is also possible to search by taxon ID:
-for example the [GBIF ID](https://www.gbif.org/species/4342) for Formicidae.
+The taxonomic index is built around the GBIF and NCBI taxonomic databases. The 
+GBIF database only uses the following core taxonomic levels: kingdom, phylum, 
+class, order, family, genus, species and subspecies. Although the NCBI uses a much
+wider range of taxonomic levels, we only include these core backbone ranks for 
+NCBI taxa, although we add superkingdom, which is used for bacteria and viruses. 
+
+It is also possible to search the taxon index using the taxon index number from 
+one of GBIF or NCBI. For example, to search for the GBIF ID for 
+[Formicidae (4234)](https://www.gbif.org/species/4342) .
 
 ```{r search_taxa_id}
-ants <- search_taxa(gbif_id = 4342)
+ants <- search_taxa(taxon_id = 4342, taxon_auth = "GBIF")
 ```
 
 ### Spatial search details


### PR DESCRIPTION
Closes #9.

This PR updates the functionality of `search_safe` to match the API of the new `safedata_server` with taxon authority information.