### PR TITLE
Minor tweaks to API links, index object and load location

### DIFF
--- a/R/index.R
+++ b/R/index.R
@@ -133,7 +133,7 @@ set_safedata_dir <- function(safedir, update = TRUE) {
 
         # Try to get the current index hashes from the SAFE Data API and
         # then check each of the three index files
-        api <- paste0(getOption("safedata.url"), "/api/index_hashes.json")
+        api <- paste0(getOption("safedata.url"), "/api/index_hashes")
         index_hashes <- try_to_download(api)
 
         if (isFALSE(index_hashes)) {

--- a/R/index.R
+++ b/R/index.R
@@ -389,7 +389,7 @@ load_index <- function() {
 
     verbose_message("Loading and caching index")
 
-    index <- jsonlite::fromJSON(getOption("safedata.index"))
+    index <- jsonlite::fromJSON(getOption("safedata.index"))$entries
 
     # format the datetime classes
     index$publication_date <- as.POSIXct(index$publication_date)

--- a/R/index.R
+++ b/R/index.R
@@ -586,11 +586,11 @@ load_location_aliases <- function() {
     if (exists("location_aliases", safedata_env)) {
         location_aliases <- get("location_aliases", safedata_env)
     } else {
-        location_aliases <- jsonlite::fromJSON(
+        location_aliases <- read.csv(
             getOption("safedata.loc_aliases")
         )
-        location_aliases <- as.data.frame(location_aliases)
-        names(location_aliases) <- c("zenodo_record_id", "location", "alias")
+        # location_aliases <- as.data.frame(location_aliases)
+        # names(location_aliases) <- c("zenodo_record_id", "location", "alias")
         assign("location_aliases", location_aliases, safedata_env)
     }
 

--- a/R/index.R
+++ b/R/index.R
@@ -300,7 +300,7 @@ download_index <- function() {
 
     path <- getOption("safedata.index")
     url <- getOption("safedata.url")
-    api <- paste0(url, "/api/metadata_index.json")
+    api <- paste0(url, "/api/index")
 
     success <- try_to_download(api, path)
 
@@ -325,7 +325,7 @@ download_gazetteer <- function() {
 
     path <- getOption("safedata.gazetteer")
     url <- getOption("safedata.url")
-    api <- paste0(url, "/api/gazetteer.json")
+    api <- paste0(url, "/api/gazetteer")
 
     success <- try_to_download(api, path)
 
@@ -351,7 +351,7 @@ download_location_aliases <- function() {
 
     path <- getOption("safedata.loc_aliases")
     url <- getOption("safedata.url")
-    api <- paste0(url, "/api/location_aliases.json")
+    api <- paste0(url, "/api/location_aliases")
     success <- try_to_download(api, path)
 
     if (!success) {


### PR DESCRIPTION
This should hopefully close #22 

I could perform `search_text()` for example. 

At the moment, `set_example_safedata_dir` seems to break things. For some reason, it breaks `get_data_dir`, possibly because `safedata.dir` is missing from `options()`. Need to investigate further.